### PR TITLE
Migrér Excel-import til admin-portal-v2 (portal-token)

### DIFF
--- a/MIGRATION-admin-portal-v2.md
+++ b/MIGRATION-admin-portal-v2.md
@@ -1,0 +1,55 @@
+# Migrering til admin-portal-v2 (portal-token)
+
+Den gamle apikey-flow mod slportal (Firebase cloud functions) er udfaset. Makroen henter nu
+data fra **admin-portal-v2** med et **portal-token** (Sanctum Bearer-token).
+
+## Hvad er ændret
+
+Kun `UserForm1.frm` (`ImportButton_Click`):
+
+- URL: `…cloudfunctions.net/integration/excel/{cpr}` → `{BASE_URL}/api/excel/employee/{cpr}`.
+- Auth-header: `apikey: <key>` → `Authorization: Bearer <token>`.
+- Det eksisterende felt (`apikeyBox`) genbruges — brugeren indsætter nu et **portal-token** i stedet
+  for den gamle apikey. **Ingen ændringer i formularens kontroller** (ingen `.frx`-ændring nødvendig).
+- `ExportButton_Click` er deaktiveret (v2 er skrivebeskyttet, intet PUT-endpoint).
+
+`pensionBrokerExport.bas` er **uændret**.
+
+## Sådan får rådgiveren et token
+
+1. Log ind i portalen (portal.cpof.dk) som rådgiver.
+2. Gå til **Indstillinger → API-nøgler** (`/settings/api-tokens`).
+3. Opret et token (vælg fx 365 dages udløb), kopiér det (vises kun én gang).
+4. Indsæt det i token-feltet i Excel-formularen.
+
+Tokenet udløber (max 1 år) — når det sker, giver opslaget en fejl (401); generér da blot et nyt
+token i portalen og indsæt det igen. Samme arbejdsgang som med den gamle nøgle.
+
+## Miljø-mapping
+
+| Radioknap | URL |
+|---|---|
+| SecureLife (prod) | `https://portal.cpof.dk` (CPOF — aktiv bruger) |
+| SecureLife test | `https://test2.portal.cpof.dk` *(bekræft public staging-URL i koden)* |
+| BedstPension | ikke migreret → viser besked |
+
+## Anbefalet (valgfrit) — relabel feltet
+
+Funktionelt virker det med det nuværende felt-navn/label. For klarhed kan label-teksten ændres fra
+"Api-nøgle" til **"Portal-token"** i VBA-editoren (kontrollen ligger i den binære `.frx`, så det
+kræver Excel — men det er kun kosmetisk og ikke nødvendigt for at det virker).
+
+## Udrulning
+
+1. Test mod prod med et rigtigt portal-token (kendt CPR udfylder "Portal import-eksport").
+2. Commit `UserForm1.frm`.
+3. **Bump `version.txt`** (0.3.0-alpha → næste) — trigger auto-update for alle rådgivere ved næste
+   workbook-åbning (`init.bas`).
+4. Merge til `main`.
+
+## Test (jf. admin-portal/docs/integrations/pb-integration-update.md)
+
+1. Indsæt portal-token + kendt CPR → "Portal import-eksport" udfyldes som før.
+2. Forkert/udløbet token → 401-fejl vises (generér nyt token).
+3. CPR uden adgang → "Du har ikke adgang til denne medarbejders virksomhed."
+4. Bekræft at alle ark-felter udfyldes som før (uændret nøgle-mapping).

--- a/UserForm1.frm
+++ b/UserForm1.frm
@@ -29,116 +29,9 @@ End Function
 
 Private Sub ExportButton_Click()
 
-Dim dict As New Scripting.Dictionary
-
-Dim JsonObject As Object
-Dim objRequest As Object
-Dim strUrl As String
-Dim blnAsync As Boolean
-Dim strResponse As String
-Dim codeResponse As String
-Dim responseStatus As Variant
-
-
-' Mandatory field
-If cprBox.value = "" Then
-    MsgBox "Du skal indsætte cprnummer", vbCritical
-    Exit Sub
-End If
- 
-
-' Mandatory field
-If apikeyBox.value = "" Then
-    MsgBox "Du skal indsætte api nøgle", vbCritical
-    Exit Sub
-End If
-
-If SecureLifeButton.value = False And BedstPensionButton.value = False And SecureLifeTestButton.value = False Then
-    MsgBox "Du skal vælge mellem bedstpension / securelife", vbCritical
-    Exit Sub
-End If
-
-Set objRequest = CreateObject("MSXML2.XMLHTTP")
-
-If SecureLifeButton = True Then
-    Debug.Print ("Securelife")
-               strUrl = "https://europe-west1-life-prod-e2f1e.cloudfunctions.net/integration/excel/" & cprBox.value
-End If
-
-If BedstPensionButton = True Then
-    Debug.Print ("Bedstpension")
-    strUrl = "https://europe-west1-bedstpension-prod.cloudfunctions.net/integration/excel/" & cprBox.value
-End If
-
-
-If SecureLifeTestButton = True Then
-    Debug.Print ("Securelife test")
-    strUrl = "https://europe-west1-life-stage-e2fb7.cloudfunctions.net/integration/excel/" & cprBox.value
-End If
-
-
-Dim key As Variant
-Dim value As Variant
-
-Dim cellIndex As Integer
-cellIndex = 6
-' Adding data to Stamoplysninger sheet
-For i = 6 To 23
-    If cellIndex = 14 Then ' Salary must be converted to montly-salary not year
-        value = Cells(cellIndex, 3).value / 12
-        key = Cells(cellIndex, 2).value
-    ElseIf cellIndex = 15 Then
-        value = Cells(cellIndex, 3).value * 100
-        key = Cells(cellIndex, 2).value
-    ElseIf cellIndex = 16 Then
-        value = Cells(cellIndex, 3).value * 100
-        key = Cells(cellIndex, 2).value
-    Else
-        value = Cells(cellIndex, 3).value
-        key = Cells(cellIndex, 2).value
-    End If
-    cellIndex = cellIndex + 1
-    Debug.Print (key)
-    Debug.Print (value)
-    dict.Add key:=key, Item:=value
-    If cellIndex = 13 Then
-        cellIndex = cellIndex + 1 ' Skip row 13 (alder)
-    End If
-Next i
-
- Dim pensionSheet As worksheet
- Dim pensionType As String
- Dim priceGroup As String
- ' Choose which sheet to fill data based on <pension type>
- pensionType = "AP Pension"
-
-Set pensionSheet = Sheets(pensionType)
-dict.Add key:="Frivilligt bidrag", Item:=pensionSheet.Cells(4, 3).value
-dict.Add key:="Tab af erhvervsevne", Item:=pensionSheet.Cells(14, 2).value * 100
-dict.Add key:="Invalidesum", Item:=pensionSheet.Cells(19, 2).value
-dict.Add key:="Dødsfaldsdækning", Item:=pensionSheet.Cells(22, 2).value * 100
-dict.Add key:="Børnerente", Item:=pensionSheet.Cells(26, 2).value
-dict.Add key:="Kritisk sygdom", Item:=pensionSheet.Cells(29, 2).value
-dict.Add key:="Kritisk sygdom til børn u. 21 år", Item:=pensionSheet.Cells(32, 2).value
-dict.Add key:="Prisgruppe", Item:=pensionSheet.Cells(3, 2).value
-
-
-
-Dim text As String
-' Generate a text of key value pair for popup & printing the dict
-For Each key In dict
-    Dim val As Variant
-    If IsNull(dict(key)) Then
-        val = ""
-    Else
-        val = CStr(dict(key))
-    End If
-    text = text + " " + key + ": " + val + vbNewLine
-Next
-
-  
-Dim answer As Integer
-answer = MsgBox(text, vbQuestion + vbYesNo + vbDefaultButton2, "Import af medarbejderen")
+' admin-portal-v2-integrationen er skrivebeskyttet (intet PUT-endpoint).
+' Eksport til portalen understøttes ikke i denne version.
+MsgBox "Eksport til portalen understøttes ikke i denne version (skrivebeskyttet integration).", vbInformation
 
 End Sub
 
@@ -149,72 +42,60 @@ Private Sub ImportButton_Click()
 
 Dim JsonObject As Object
 Dim objRequest As Object
+Dim strBaseUrl As String
 Dim strUrl As String
-Dim blnAsync As Boolean
 Dim strResponse As String
-Dim codeResponse As String
 Dim responseStatus As Variant
 
-
-' Mandatory field
+' Mandatory fields
 If cprBox.value = "" Then
     MsgBox "Du skal indsætte cprnummer", vbCritical
     Exit Sub
 End If
- 
 
-' Mandatory field
+' apikeyBox bruges nu til portal-tokenet (genereres i portalen under /settings/api-tokens).
 If apikeyBox.value = "" Then
-    MsgBox "Du skal indsætte api nøgle", vbCritical
+    MsgBox "Du skal indsætte portal-token", vbCritical
     Exit Sub
 End If
 
 If SecureLifeButton.value = False And BedstPensionButton.value = False And SecureLifeTestButton.value = False Then
-    MsgBox "Du skal vælge mellem bedstpension / securelife", vbCritical
+    MsgBox "Du skal vælge miljø", vbCritical
     Exit Sub
 End If
 
+If BedstPensionButton.value = True Then
+    MsgBox "BedstPension er endnu ikke migreret til den nye portal.", vbInformation
+    Exit Sub
+End If
+
+' Map miljø-valg til admin-portal-v2 base-URL.
+If SecureLifeTestButton.value = True Then
+    strBaseUrl = "https://test2.portal.cpof.dk" ' TODO: bekræft public staging-URL
+Else
+    strBaseUrl = "https://portal.cpof.dk" ' CPOF (prod) — aktiv bruger
+End If
+
+strUrl = strBaseUrl & "/api/excel/employee/" & cprBox.value
+
 Set objRequest = CreateObject("MSXML2.XMLHTTP")
-
-If SecureLifeButton = True Then
-    Debug.Print ("Securelife")
-    strUrl = "https://europe-west1-life-prod-e2f1e.cloudfunctions.net/integration/excel/" & cprBox.value
-End If
-
-If BedstPensionButton = True Then
-    Debug.Print ("Bedstpension")
-    strUrl = "https://europe-west1-bedstpension-prod.cloudfunctions.net/integration/excel/" & cprBox.value
-End If
-
-
-If SecureLifeTestButton = True Then
-    Debug.Print ("Securelife test")
-    strUrl = "https://europe-west1-life-stage-e2fb7.cloudfunctions.net/integration/excel/" & cprBox.value
-End If
-
-
-blnAsync = True
-
 With objRequest
-    .Open "GET", strUrl, blnAsync
-    .setRequestHeader "Content-Type", "application/json"
-    .setRequestHeader "apikey", apikeyBox.value
+    .Open "GET", strUrl, False
+    .setRequestHeader "Accept", "application/json"
+    .setRequestHeader "Authorization", "Bearer " & apikeyBox.value
     .send
-    'spin wheels whilst waiting for response
-    While objRequest.readyState <> 4
-        DoEvents
-    Wend
     strResponse = .responseText
     responseStatus = .Status
 End With
- Debug.Print (responseStatus)
- 
- If Not responseStatus = 200 Then
+Debug.Print (responseStatus)
+
+If Not responseStatus = 200 Then
+    ' 401 = token udløbet/ugyldigt -> generér nyt token i portalen og indsæt igen.
     MsgBox "ERROR: " & strResponse
     Exit Sub
- Else
+Else
     Set JsonObject = JsonConverter.ParseJson(strResponse)
- End If
+End If
 
 
 Dim text As String


### PR DESCRIPTION
## Hvorfor

Rådgiverværktøjet (denne Excel-makro) fejler med `ERROR: {"message":"Unauthorized - Invalid apikey"}`. Makroen bruger stadig den **gamle** apikey-flow mod slportal (Firebase cloud functions), og nøglerne er ikke længere gyldige dér (slportal udfases til fordel for admin-portal-v2).

Verificeret: den gamle Firebase-funktion lever stadig og giver præcis samme 401 for enhver ugyldig nøgle, mens den nye admin-portal-v2 API er live i prod.

## Hvad

Skifter `ImportButton_Click` til admin-portal-v2 med et **portal-token** (Sanctum Bearer):

- URL: `…cloudfunctions.net/integration/excel/{cpr}` → `{BASE_URL}/api/excel/employee/{cpr}`
- Auth: header `apikey: <key>` → `Authorization: Bearer <token>`
- Genbruger det eksisterende felt — brugeren indsætter nu et portal-token (genereres under `/settings/api-tokens`). **Ingen ændring af formularens kontroller**, så `.frx` er uændret og auto-update virker rent (kun tekst-ændring).
- `ExportButton_Click` deaktiveret — v2 er skrivebeskyttet (intet PUT-endpoint).

Miljø-mapping: prod → `portal.cpof.dk` (CPOF), test → staging, BedstPension → "ikke migreret".

JSON-nøglerne i svaret er uændrede, så ark-mappingen i "Portal import-eksport" rører vi ikke.

## Sådan får rådgiveren et token
Portalen → Indstillinger → API-nøgler → opret (fx 365 dages udløb) → kopiér → indsæt i Excel-feltet. Udløber tokenet (401) genereres blot et nyt — samme arbejdsgang som den gamle nøgle.

## Før merge / rollout
- [ ] Bekræft public **staging-URL** for test-knappen (`test2.portal.cpof.dk` er placeholder)
- [ ] Test mod prod med et rigtigt portal-token + kendt CPR
- [ ] **Bump `version.txt`** (0.3.0-alpha → næste) for at trigge auto-update hos alle rådgivere
- [ ] (valgfrit, kosmetisk) relabel feltet "Api-nøgle" → "Portal-token" i VBA-editoren

Detaljer i `MIGRATION-admin-portal-v2.md`. Kontrakt: admin-portal `docs/integrations/pb-integration-update.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)